### PR TITLE
The pyproject now should accept a wider range of Python versions, and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,14 @@ Use Pip to install the latest release of Storybro:
 To install the development version:
 
     pip install git+https://github.com/storybro/storybro.git
-    
+
+Or run this if you have cloned the source and are in that directory:
+
+    pip install .
+
 *(Optional)* To use the model torrenting in Storybro, install [Aria2](https://aria2.github.io/) and ensure it is on your `$PATH`.
+
+**For troubleshooting [see the wiki](https://github.com/storybro/storybro/wiki/Troubleshooting-Guide)**
 
 # Playing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/storybro/storybro"
 keywords = ['gpt2', 'gpt-2']
 
 [tool.poetry.dependencies]
-python = "~3.6.8"  # Compatible python versions must be declared here
+python = ">=3.4 <3.8"  # Compatible python versions must be declared here
 google-cloud-storage = "1.23.0"
 gsutil = "4.46"
 numpy = "1.18.0"


### PR DESCRIPTION
The pyproject now should accept a wider range of Python versions, and the README contains a link to the troubleshooting page and the 'pip install .' command.