### PR TITLE
Project accepted too low Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/storybro/storybro"
 keywords = ['gpt2', 'gpt-2']
 
 [tool.poetry.dependencies]
-python = ">=3.4 <3.8"  # Compatible python versions must be declared here
+python = ">=3.5 <3.8"  # Compatible python versions must be declared here
 google-cloud-storage = "1.23.0"
 gsutil = "4.46"
 numpy = "1.18.0"


### PR DESCRIPTION
The project accepted Python 3.4. However, cmd2 requires Python 3.5 or newer. This commit should resolve the problem.

### 🧪 How to Test

Build with docker. If it does not complain about Python versions, it should be fine.