### PR TITLE
Previously inserted "!" when that was used as shortcut for /raw

### DIFF
--- a/storybro/play/player.py
+++ b/storybro/play/player.py
@@ -86,7 +86,7 @@ class Player(cmd2.Cmd):
         if line == "eof":
             line = "quit"
         elif line.startswith("!"):
-            line = f"raw {line}"
+            line = f"raw {line[1:]}"
         elif not line.startswith("/"):
             line = f"commit {line}"
         else:


### PR DESCRIPTION
This created responses with messed up punctuation. `/raw` did not do this.

## 🧪 How to Test

`storybro play <name>`
`!<something>`
`/list`
None of the listed blocks should have a `!` at their beginning.