### PR TITLE
Add `models delete` command

### DIFF
--- a/storybro/cli/commands/models/__init__.py
+++ b/storybro/cli/commands/models/__init__.py
@@ -7,7 +7,9 @@ def models(config):
 
 from .get import get
 from .list import list
+from .delete import delete
 
 models.add_command(get)
 models.add_command(list)
+models.add_command(delete)
 

--- a/storybro/cli/commands/models/delete.py
+++ b/storybro/cli/commands/models/delete.py
@@ -1,0 +1,19 @@
+import shutil
+
+import click
+
+
+@click.command()
+@click.argument('name')
+@click.pass_obj
+def delete(config, name):
+    '''Delete a model'''
+    installed = config.model_manager.models.keys()
+
+    if name not in installed:
+        click.echo(f"The model `{name}` wasn't found.")
+        return
+
+    model = config.model_manager.models.get(name)
+    shutil.rmtree(model.root_path)
+    click.echo(f"Deleted model `{name}`.")


### PR DESCRIPTION
## 🎉 Issues resolved:

- closes #6

## 🧪 How to Test

I recommend making a copy of `model_v5` before testing this, so you will not have to re-download it.
`storybro models delete model_v5` (you will need model_v5 beforehand)
`storybro models list`
It should show `model_v5` is not installed.